### PR TITLE
Fix bb shell example function in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,8 +103,6 @@ To easily use these signals add the following function to your .bashrc:
 ```bash
 bb() {
     local signal
-    local cmd
-    [[ "$#" -lt 1 ]] && echo "Usage: bb ( b[lock] | u[nblock] | p[revious] | n[ext] | t[oggle] | t[oggle]b[lock] |...)"  && return 0
     case "$1" in
         '')  blockify-dbus get 2>/dev/null && return 0;;
         ex|exit)
@@ -129,7 +127,7 @@ bb() {
             signal='RTMIN+12';;   # Toggle play interlude song
         itr|itoggleresume)
             signal='RTMIN+13';;   # Toggle interlude resume
-        *) echo "Bad option" && return 0;;
+        *) echo "Usage: bb ( b[lock] | u[nblock] | p[revious] | n[ext] | t[oggle] | t[oggle]b[lock] |...)" && return 0;;
     esac
     pkill --signal "$signal" -f 'python.*blockify'
 }


### PR DESCRIPTION
Right now running `bb` will not return the currently playing song as described in the readme, but the usage info.

This patch fixed that. Displaying the current song is now possible and the usage is only show if an unknown command is run (e.g. when running `bb h` or `bb help` :wink:).
