### PR TITLE
remove references to *_icon_buf

### DIFF
--- a/blockify/gui.py
+++ b/blockify/gui.py
@@ -626,11 +626,11 @@ class BlockifyUI(Gtk.Window):
     def update_icons(self):
         if self.b.found and not self.statusicon_found:
             self.set_icon_from_file(self.red_icon_file)
-            self.status_icon.set_from_pixbuf(self.red_icon_buf)
+            #self.status_icon.set_from_pixbuf(self.red_icon_buf)
             self.statusicon_found = True
         elif not self.b.found and self.statusicon_found:
             self.set_icon_from_file(self.blue_icon_file)
-            self.status_icon.set_from_pixbuf(self.blue_icon_buf)
+            #self.status_icon.set_from_pixbuf(self.blue_icon_buf)
             self.statusicon_found = False
 
     def update_slider(self):


### PR DESCRIPTION
Changes done in https://github.com/serialoverflow/blockify/commit/b30ebedb86d32afbfa6af3fa1e4b10a3acf1ece6 removed variables red_icon_buf and blue_icon_buf.
These were used in other parts in the gui module, causing an exception during the exception (when ads popped up). I therefore commented the lines referencing the missing variables and the problem seems to be solved (exception doesn't raise anymore).